### PR TITLE
Removed 1 unnecessary stubbing in SimilarMethodNameFinderTest.java

### DIFF
--- a/src/test/java/org/givwenzen/text/matching/levenshtein/SimilarMethodNameFinderTest.java
+++ b/src/test/java/org/givwenzen/text/matching/levenshtein/SimilarMethodNameFinderTest.java
@@ -36,8 +36,6 @@ public class SimilarMethodNameFinderTest {
       when(mockMethod1.getDomainStepPattern()).thenReturn(TEST_NAME + "!");
 
       MethodAndInvocationTarget mockMethod2 = mock(MethodAndInvocationTarget.class);
-      when(mockMethod2.getDomainStepPattern()).thenReturn(TEST_NAME + "!0@#$%^");
-
       Collection<MethodAndInvocationTarget> steps = new ArrayList<MethodAndInvocationTarget>();
       steps.add(mockMethod1);
 


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 stubbing which is created in `SimilarMethodNameFinderTest.shouldFindMethodStringsWithDistanceLessThanMaximumDistance` but never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.