### PR TITLE
Removed 1 unnecessary stubbing in LuceneSimilarityTest.java

### DIFF
--- a/src/test/java/org/givwenzen/text/matching/lucene/SecondLuceneSimilarityTest.java
+++ b/src/test/java/org/givwenzen/text/matching/lucene/SecondLuceneSimilarityTest.java
@@ -23,27 +23,24 @@ import static org.fest.assertions.Assertions.*;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
-public class LuceneSimilarityTest {
+public class SecondLuceneSimilarityTest {
    private String helloTestAnnotation = "hello test";
    private String helloWorldAnnotation = "hello world";
    private List<MethodAndInvocationTarget> steps = new ArrayList<MethodAndInvocationTarget>();
    private LuceneSimilarity luceneSimilarity;
    private MethodAndInvocationTarget helloTest;
    private MethodAndInvocationTarget helloWorld;
-   
-   @Test
-   public void shouldListClosestNameFirst() throws Exception {
-      //given
-      steps.add(helloTest);
-      steps.add(helloWorld);
 
-      // when
-      Collection<String> methods = luceneSimilarity.findSimilarMethods("hello lah world", steps);
+   @Test
+   public void shouldFindMethodWithAtLeastOneWordInCommon() throws Exception {
+      // given
+      steps.add(helloTest);
+
+      //when
+      Collection<String> methods = luceneSimilarity.findSimilarMethods("hello world", steps);
 
       //then
-      List<String> methodList = new ArrayList<String>(methods);
-      assertThat(methodList.get(0)).isEqualTo(helloWorldAnnotation);
-      assertThat(methodList.get(1)).isEqualTo(helloTestAnnotation);
+      assertThat(methods).contains(helloTestAnnotation);
    }
    
    @Before
@@ -53,8 +50,6 @@ public class LuceneSimilarityTest {
       when(helloTest.getDomainStepPattern()).thenReturn(helloTestAnnotation);
 
       helloWorld = mock(MethodAndInvocationTarget.class);
-      when(helloWorld.getDomainStepPattern()).thenReturn(helloWorldAnnotation);
-
       luceneSimilarity = new LuceneSimilarity();
    }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 stubbing (`when(helloWorld.getDomainStepPattern()).thenReturn(helloWorldAnnotation);`) is created in `LuceneSimilarityTest.setUp`but never executed by the test `LuceneSimilarityTest.shouldFindMethodWithAtLeastOneWordInCommon`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.